### PR TITLE
Feat/translation details popup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run test && npm run lint && npm run format
+yarn test && yarn lint && yarn format

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Check out the deployed app online at https://dovahzul-translator-jg.netlify.app/
 
 ## TODO
 
-- Translation should have a popup window with full translations
 - Take input as prompt from LLM
 
 ## Ai disclaimer

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -23,3 +23,8 @@ test("Can click 'Clear text' button to clear text", async ({ page }) => {
 	await indexPage.navigateTo(page, indexPage.url);
 	await indexPage.typeTextAndClear(page, 'Rawr rawr rawr');
 });
+
+test("Can click on a translated word to display additional information", async ({ page }) => {
+	await indexPage.navigateTo(page, indexPage.url);
+	await indexPage.assertTranslatedTextDialogue(page, "My fire burns the earth.");
+})

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -24,7 +24,7 @@ test("Can click 'Clear text' button to clear text", async ({ page }) => {
 	await indexPage.typeTextAndClear(page, 'Rawr rawr rawr');
 });
 
-test("Can click on a translated word to display additional information", async ({ page }) => {
+test('Can click on a translated word to display additional information', async ({ page }) => {
 	await indexPage.navigateTo(page, indexPage.url);
-	await indexPage.assertTranslatedTextDialogue(page, "My fire burns the earth.");
-})
+	await indexPage.assertTranslatedTextDialogue(page, 'My fire burns the earth.');
+});

--- a/e2e/pages/index-page.ts
+++ b/e2e/pages/index-page.ts
@@ -94,10 +94,10 @@ export class IndexPage extends BasePage {
 
 	private async clickButton(page: Page, name: string) {
 		return test.step('click on a button element by name', async () => {
-			const btn = page.getByRole('button', { name});
+			const btn = page.getByRole('button', { name });
 			await expect(btn).toBeInViewport();
 			await btn.click();
-		})
+		});
 	}
 
 	private async assertTooltipContent(page: Page, title: string, english: string, dovahzul: string) {
@@ -105,7 +105,7 @@ export class IndexPage extends BasePage {
 			await expect(this.tooltip(page)).toContainText(title);
 			await expect(this.tooltip(page)).toContainText(`English: ${english}`);
 			await expect(this.tooltip(page)).toContainText(`Dovahzul: ${dovahzul}`);
-		})
+		});
 	}
 
 	private async tabPress(page: Page) {
@@ -141,10 +141,10 @@ export class IndexPage extends BasePage {
 
 			await this.clickButton(page, 'dii');
 			await this.assertTooltipIsVisible(page);
-			await this.assertTooltipContent(page, 'dii', 'My', 'dii')
+			await this.assertTooltipContent(page, 'dii', 'My', 'dii');
 
-			await this.tabPress(page)
-			await this.assertTooltipContent(page, 'yol', 'fire', 'yol')
+			await this.tabPress(page);
+			await this.assertTooltipContent(page, 'yol', 'fire', 'yol');
 		});
 	}
 }

--- a/e2e/pages/index-page.ts
+++ b/e2e/pages/index-page.ts
@@ -8,6 +8,7 @@ export class IndexPage extends BasePage {
 	clearButton: (page: Page) => Locator;
 	headingTwo: (page: Page, name: string) => Locator;
 	changeTranslationModeButton: (page: Page) => Locator;
+	tooltip: (page: Page) => Locator;
 
 	constructor() {
 		super();
@@ -17,6 +18,7 @@ export class IndexPage extends BasePage {
 		this.translatedTextBox = (page: Page) => page.getByLabel('Translated text');
 		this.clearButton = (page: Page) => page.getByRole('button', { name: 'Clear text' });
 		this.headingTwo = (page: Page, name: string) => page.getByRole('heading', { name });
+		this.tooltip = (page: Page) => page.getByRole('dialog');
 		this.changeTranslationModeButton = (page: Page) =>
 			page.getByRole('button', { name: 'Click to reverse translation' });
 	}
@@ -78,6 +80,38 @@ export class IndexPage extends BasePage {
 		});
 	}
 
+	private async assertTooltipIsHidden(page: Page) {
+		return test.step('Tooltip is visible', async () => {
+			await expect(this.tooltip(page)).toBeHidden();
+		});
+	}
+
+	private async assertTooltipIsVisible(page: Page) {
+		return test.step('Tooltip is visible', async () => {
+			await expect(this.tooltip(page)).toBeVisible();
+		});
+	}
+
+	private async clickButton(page: Page, name: string) {
+		return test.step('click on a button element by name', async () => {
+			const btn = page.getByRole('button', { name});
+			await expect(btn).toBeInViewport();
+			await btn.click();
+		})
+	}
+
+	private async assertTooltipContent(page: Page, title: string, english: string, dovahzul: string) {
+		return test.step('Assert tooltip content', async () => {
+			await expect(this.tooltip(page)).toContainText(title);
+			await expect(this.tooltip(page)).toContainText(`English: ${english}`);
+			await expect(this.tooltip(page)).toContainText(`Dovahzul: ${dovahzul}`);
+		})
+	}
+
+	private async tabPress(page: Page) {
+		await page.keyboard.press('Tab');
+	}
+
 	public async translateDovahzulToEnglish(page: Page, inputText: string, expectedText: string) {
 		return test.step('Translate Dovahzul to English', async () => {
 			await this.changeTranslationMode(page);
@@ -90,12 +124,27 @@ export class IndexPage extends BasePage {
 	}
 
 	public async typeTextAndClear(page: Page, inputText: string) {
-		return test.step(`Type text and into the input box and clear it`, async () => {
+		return test.step(`Type text into the input box and clear it`, async () => {
 			await this.assertInputBoxExists(page);
 			await this.typeTextIntoInputBox(page, inputText);
 
 			await this.clickTheClearButton(page);
 			await this.assertTextInInputBox(page, '');
+		});
+	}
+
+	public async assertTranslatedTextDialogue(page: Page, inputText: string) {
+		return test.step(`Type text and the input box and assert that a dialogue box renders`, async () => {
+			await this.assertInputBoxExists(page);
+			await this.typeTextIntoInputBox(page, inputText);
+			await this.assertTooltipIsHidden(page);
+
+			await this.clickButton(page, 'dii');
+			await this.assertTooltipIsVisible(page);
+			await this.assertTooltipContent(page, 'dii', 'My', 'dii')
+
+			await this.tabPress(page)
+			await this.assertTooltipContent(page, 'yol', 'fire', 'yol')
 		});
 	}
 }

--- a/e2e/pages/index-page.ts
+++ b/e2e/pages/index-page.ts
@@ -60,7 +60,7 @@ export class IndexPage extends BasePage {
 	private async assertCorrectHeadingTwoText(page: Page, isEnglishToDovahzul: boolean) {
 		return test.step('Assert that heading two has the correct text', async () => {
 			const expectedText = isEnglishToDovahzul ? 'English to Dovahzul' : 'Dovahzul to English';
-			await expect(this.headingTwo(page, expectedText)).toBeInViewport();
+			await expect(this.headingTwo(page, expectedText)).toBeVisible();
 		});
 	}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,10 @@
 <main>
 	<h1>Dovahzul language translator</h1>
 
+	<p>
+		Hover over a translated word to learn more. If a word has a <span class="green-line">green line</span> underneath it then a translation was found.
+	</p>
+
 	<Translator />
 
 	<section>
@@ -30,4 +34,7 @@
 </main>
 
 <style>
+	.green-line {
+		border-bottom: green 4px solid;
+	}
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,9 @@
 	<h1>Dovahzul language translator</h1>
 
 	<p>
-		Hover over a translated word to learn more. If a word has a <span class="green-line">green line</span> underneath it then a translation was found.
+		Hover over a translated word to learn more. If a word has a <span class="green-line"
+			>green line</span
+		> underneath it then a translation was found.
 	</p>
 
 	<Translator />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,7 @@
 	<h1>Dovahzul language translator</h1>
 
 	<p>
-		Hover over a translated word to learn more. If a word has a <span class="green-line"
+		Click on a translated word to learn more. If a word has a <span class="green-line"
 			>green line</span
 		> underneath it then a translation was found.
 	</p>

--- a/src/lib/TranslatedTextWindow.svelte
+++ b/src/lib/TranslatedTextWindow.svelte
@@ -1,33 +1,17 @@
 <script lang="ts">
-	import type { TranslatedText } from './utils/translate-text';
-
-	interface TranslatedTextWindowProps {
-		translatedText: TranslatedText[];
-		translateEnglishToDovahzul: boolean;
-	}
+	import TranslatedWord from "./TranslatedWord.svelte";
+	import type {TranslatedTextWindowProps} from "./translated-text-window-props.types";
 
 	// Caveat: If an English word translates to more than one Dovahzul word then the first translation in the array is returned
-	const { translatedText, translateEnglishToDovahzul }: TranslatedTextWindowProps = $props();
+	const {translatedText, translateEnglishToDovahzul }: TranslatedTextWindowProps = $props();
 
 	const displayAreaClass = $derived(
 		translateEnglishToDovahzul ? 'english-dovahzul-translation' : 'dovahzul-english-translation'
 	);
-
-	const getTranslatedWordToDisplay = (obj: TranslatedText) => {
-		if (translateEnglishToDovahzul) {
-			return obj.dovahzul !== null ? `${obj.dovahzul[0]} ` : `${obj.english} `;
-		}
-
-		return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
-	};
 </script>
 
 <div aria-label="translated text" class={displayAreaClass}>
-	{#each translatedText as obj, index (index)}
-		<div class={obj.translated ? 'translated-word' : 'untranslated-word'}>
-			{getTranslatedWordToDisplay(obj)}
-		</div>
-	{/each}
+<TranslatedWord translatedText={translatedText} translateEnglishToDovahzul={translateEnglishToDovahzul}/>
 </div>
 
 <style>
@@ -55,18 +39,5 @@
 		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 		grid-gap: 2px;
 		font-family: serif;
-	}
-
-	.translated-word {
-		border-bottom: green 4px solid;
-		text-align: center;
-		font-size: 2rem;
-		margin: auto 0.3vw auto 0.3vw;
-	}
-
-	.untranslated-word {
-		text-align: center;
-		font-size: 2rem;
-		margin: auto 0.5vw auto 0.5vw;
 	}
 </style>

--- a/src/lib/TranslatedTextWindow.svelte
+++ b/src/lib/TranslatedTextWindow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import TranslatedWord from './TranslatedWord.svelte';
-	import type {TranslatedText} from "./utils/translate-text";
+	import type { TranslatedText } from './utils/translate-text';
 
 	interface TranslatedTextWindowProps {
 		translatedText: TranslatedText[];
@@ -17,7 +17,7 @@
 
 <div aria-label="translated text" class={displayAreaClass}>
 	{#each translatedText as translatedWord, index (index)}
-		<TranslatedWord translatedWord={translatedWord} {translateEnglishToDovahzul} />
+		<TranslatedWord {translatedWord} {translateEnglishToDovahzul} />
 	{/each}
 </div>
 

--- a/src/lib/TranslatedTextWindow.svelte
+++ b/src/lib/TranslatedTextWindow.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-	import TranslatedWord from "./TranslatedWord.svelte";
-	import type {TranslatedTextWindowProps} from "./translated-text-window-props.types";
+	import TranslatedWord from './TranslatedWord.svelte';
+	import type {TranslatedText} from "./utils/translate-text";
+
+	interface TranslatedTextWindowProps {
+		translatedText: TranslatedText[];
+		translateEnglishToDovahzul: boolean;
+	}
 
 	// Caveat: If an English word translates to more than one Dovahzul word then the first translation in the array is returned
-	const {translatedText, translateEnglishToDovahzul }: TranslatedTextWindowProps = $props();
+	const { translatedText, translateEnglishToDovahzul }: TranslatedTextWindowProps = $props();
 
 	const displayAreaClass = $derived(
 		translateEnglishToDovahzul ? 'english-dovahzul-translation' : 'dovahzul-english-translation'
@@ -11,7 +16,9 @@
 </script>
 
 <div aria-label="translated text" class={displayAreaClass}>
-<TranslatedWord translatedText={translatedText} translateEnglishToDovahzul={translateEnglishToDovahzul}/>
+	{#each translatedText as translatedWord, index (index)}
+		<TranslatedWord translatedWord={translatedWord} {translateEnglishToDovahzul} />
+	{/each}
 </div>
 
 <style>

--- a/src/lib/TranslatedTextWindow.svelte
+++ b/src/lib/TranslatedTextWindow.svelte
@@ -58,7 +58,7 @@
 	}
 
 	.translated-word {
-		background-color: green;
+		border-bottom: green 4px solid;
 		text-align: center;
 		font-size: 2rem;
 		margin: auto 0.3vw auto 0.3vw;

--- a/src/lib/TranslatedTextWindow.svelte
+++ b/src/lib/TranslatedTextWindow.svelte
@@ -7,8 +7,9 @@
 		translateEnglishToDovahzul: boolean;
 	}
 
-	// Caveat: If an English word translates to more than one Dovahzul word then the first translation in the array is returned
 	const { translatedText, translateEnglishToDovahzul }: TranslatedTextWindowProps = $props();
+
+	// Caveat: If an English word translates to more than one Dovahzul word then the first translation in the array is returned
 
 	const displayAreaClass = $derived(
 		translateEnglishToDovahzul ? 'english-dovahzul-translation' : 'dovahzul-english-translation'

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -8,8 +8,10 @@
 
 	const { translatedWord, translateEnglishToDovahzul }: TranslatedWordProps = $props();
 
-    let isUserHovering = $state(false);
-    const showPopup = $derived(isUserHovering && translateEnglishToDovahzul && translatedWord.translated);
+	let isUserHovering = $state(false);
+	const showPopup = $derived(
+		isUserHovering && translateEnglishToDovahzul && translatedWord.translated
+	);
 
 	const getTranslatedWordToDisplay = (obj: TranslatedText) => {
 		if (translateEnglishToDovahzul) {
@@ -19,39 +21,45 @@
 		return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
 	};
 
-    const userFocusOnTooltip = () => isUserHovering = true;
-    const userBlueOnTooltip = () => isUserHovering = false;
+	const userFocusOnTooltip = () => (isUserHovering = true);
+	const userBlueOnTooltip = () => (isUserHovering = false);
 </script>
 
 <article>
+	{#if showPopup}
+		<!-- Has blue and focus events -->
+		<!-- svelte-ignore a11y_click_events_have_key_events-->
+		<div id="tooltip" tabindex="0" role="dialog" onclick={userBlueOnTooltip}>
+			<p class="tooltip-title">{translatedWord.dovahzul?.[0] ?? ''}</p>
 
-    {#if showPopup}
-        <!-- Has blue and focus events -->
-        <!-- svelte-ignore a11y_click_events_have_key_events-->
-    <div id="tooltip" tabindex="0" role="dialog" onclick={userBlueOnTooltip} >
-<p class="tooltip-title">{ translatedWord.dovahzul?.[0] ?? ''}</p>
+			<span>{`English: ${translatedWord.english}`}</span>
 
-            <span>{`English: ${translatedWord.english}`}</span>
+			{#if translatedWord.translated && translatedWord.dovahzul?.length}
+				<span>{`Dovahzul: ${translatedWord.dovahzul.join(', ')}`}</span>
+			{/if}
+		</div>
+	{/if}
 
-        {#if translatedWord.translated && translatedWord.dovahzul?.length}
-            <span>{`Dovahzul: ${translatedWord.dovahzul.join(', ')}`}</span>
-            {/if}
-
-    </div>
-        {/if}
-
-    <!-- Has blue and focus events -->
-    <!-- svelte-ignore a11y_click_events_have_key_events-->
-    <div tabindex="0" aria-describedby="tooltip" id="anchor-ref" role="button" class={translatedWord.translated ? 'translated-word' : 'untranslated-word'} onclick={userFocusOnTooltip} onfocus={userFocusOnTooltip} onblur={userBlueOnTooltip}>
-        {getTranslatedWordToDisplay(translatedWord)}
-    </div>
+	<!-- Has blue and focus events -->
+	<!-- svelte-ignore a11y_click_events_have_key_events-->
+	<div
+		tabindex="0"
+		aria-describedby="tooltip"
+		id="anchor-ref"
+		role="button"
+		class={translatedWord.translated ? 'translated-word' : 'untranslated-word'}
+		onclick={userFocusOnTooltip}
+		onfocus={userFocusOnTooltip}
+		onblur={userBlueOnTooltip}
+	>
+		{getTranslatedWordToDisplay(translatedWord)}
+	</div>
 </article>
 
-
 <style>
-    #anchor-ref {
-        anchor-name: --word;
-    }
+	#anchor-ref {
+		anchor-name: --word;
+	}
 
 	.translated-word {
 		border-bottom: green 4px solid;
@@ -66,22 +74,22 @@
 		margin: auto 0.5vw auto 0.5vw;
 	}
 
-    #tooltip {
-        position: absolute;
-        position-anchor: --word;
-        position-area: top;
-        padding: 16px;
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        z-index: 1000;
-        border: white solid 4px;
-        font-family: serif;
-        background-color: #696969;
-    }
+	#tooltip {
+		position: absolute;
+		position-anchor: --word;
+		position-area: top;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		z-index: 1000;
+		border: white solid 4px;
+		font-family: serif;
+		background-color: #696969;
+	}
 
-    .tooltip-title {
-        font-weight: bold;
-        font-family: 'Dovahzul', serif;
-    }
+	.tooltip-title {
+		font-weight: bold;
+		font-family: 'Dovahzul', serif;
+	}
 </style>

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -27,7 +27,7 @@
 
 <article>
 	{#if showPopup}
-		<!-- Has blue and focus events -->
+		<!-- Has blur and focus events -->
 		<!-- svelte-ignore a11y_click_events_have_key_events-->
 		<div id="tooltip" tabindex="0" role="dialog" onclick={userBlueOnTooltip}>
 			<p class="tooltip-title">{translatedWord.dovahzul?.[0] ?? ''}</p>
@@ -40,7 +40,7 @@
 		</div>
 	{/if}
 
-	<!-- Has blue and focus events -->
+	<!-- Has blur and focus events -->
 	<!-- svelte-ignore a11y_click_events_have_key_events-->
 	<div
 		tabindex="0"

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+    import type {TranslatedText} from "./utils/translate-text";
+    import type {TranslatedTextWindowProps} from "./translated-text-window-props.types";
+
+    const {translatedText, translateEnglishToDovahzul}: TranslatedTextWindowProps = $props();
+
+    const getTranslatedWordToDisplay = (obj: TranslatedText) => {
+        if (translateEnglishToDovahzul) {
+            return obj.dovahzul !== null ? `${obj.dovahzul[0]} ` : `${obj.english} `;
+        }
+
+        return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
+    };
+</script>
+
+{#each translatedText as obj, index (index)}
+    <div class={obj.translated ? 'translated-word' : 'untranslated-word'}>
+        {getTranslatedWordToDisplay(obj)}
+    </div>
+{/each}
+
+
+<style>
+    .translated-word {
+        border-bottom: green 4px solid;
+        text-align: center;
+        font-size: 2rem;
+        margin: auto 0.3vw auto 0.3vw;
+    }
+
+    .untranslated-word {
+        text-align: center;
+        font-size: 2rem;
+        margin: auto 0.5vw auto 0.5vw;
+    }
+</style>

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -8,6 +8,9 @@
 
 	const { translatedWord, translateEnglishToDovahzul }: TranslatedWordProps = $props();
 
+    let isUserHovering = $state(false);
+    const showPopup = $derived(isUserHovering && translateEnglishToDovahzul && translatedWord.translated);
+
 	const getTranslatedWordToDisplay = (obj: TranslatedText) => {
 		if (translateEnglishToDovahzul) {
 			return obj.dovahzul !== null ? `${obj.dovahzul[0]} ` : `${obj.english} `;
@@ -15,13 +18,41 @@
 
 		return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
 	};
+
+    const userFocusOnTooltip = () => isUserHovering = true;
+    const userBlueOnTooltip = () => isUserHovering = false;
 </script>
 
-<div class={translatedWord.translated ? 'translated-word' : 'untranslated-word'}>
-	{getTranslatedWordToDisplay(translatedWord)}
-</div>
+<article>
+
+    {#if showPopup}
+        <!-- Has blue and focus events -->
+        <!-- svelte-ignore a11y_click_events_have_key_events-->
+    <div id="tooltip" tabindex="0" role="dialog" onclick={userBlueOnTooltip} >
+<p class="tooltip-title">{ translatedWord.dovahzul?.[0] ?? ''}</p>
+
+            <span>{`English: ${translatedWord.english}`}</span>
+
+        {#if translatedWord.translated && translatedWord.dovahzul?.length}
+            <span>{`Dovahzul: ${translatedWord.dovahzul.join(', ')}`}</span>
+            {/if}
+
+    </div>
+        {/if}
+
+    <!-- Has blue and focus events -->
+    <!-- svelte-ignore a11y_click_events_have_key_events-->
+    <div tabindex="0" aria-describedby="tooltip" id="anchor-ref" role="button" class={translatedWord.translated ? 'translated-word' : 'untranslated-word'} onclick={userFocusOnTooltip} onfocus={userFocusOnTooltip} onblur={userBlueOnTooltip}>
+        {getTranslatedWordToDisplay(translatedWord)}
+    </div>
+</article>
+
 
 <style>
+    #anchor-ref {
+        anchor-name: --word;
+    }
+
 	.translated-word {
 		border-bottom: green 4px solid;
 		text-align: center;
@@ -34,4 +65,23 @@
 		font-size: 2rem;
 		margin: auto 0.5vw auto 0.5vw;
 	}
+
+    #tooltip {
+        position: absolute;
+        position-anchor: --word;
+        position-area: top;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        z-index: 1000;
+        border: white solid 4px;
+        font-family: serif;
+        background-color: #696969;
+    }
+
+    .tooltip-title {
+        font-weight: bold;
+        font-family: 'Dovahzul', serif;
+    }
 </style>

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import type { TranslatedText } from './utils/translate-text';
 
-    interface TranslatedWordProps {
-        translatedWord: TranslatedText;
-        translateEnglishToDovahzul: boolean;
-    }
+	interface TranslatedWordProps {
+		translatedWord: TranslatedText;
+		translateEnglishToDovahzul: boolean;
+	}
 
 	const { translatedWord, translateEnglishToDovahzul }: TranslatedWordProps = $props();
 
@@ -17,10 +17,9 @@
 	};
 </script>
 
-
-	<div class={translatedWord.translated ? 'translated-word' : 'untranslated-word'}>
-		{getTranslatedWordToDisplay(translatedWord)}
-	</div>
+<div class={translatedWord.translated ? 'translated-word' : 'untranslated-word'}>
+	{getTranslatedWordToDisplay(translatedWord)}
+</div>
 
 <style>
 	.translated-word {

--- a/src/lib/TranslatedWord.svelte
+++ b/src/lib/TranslatedWord.svelte
@@ -1,36 +1,38 @@
 <script lang="ts">
-    import type {TranslatedText} from "./utils/translate-text";
-    import type {TranslatedTextWindowProps} from "./translated-text-window-props.types";
+	import type { TranslatedText } from './utils/translate-text';
 
-    const {translatedText, translateEnglishToDovahzul}: TranslatedTextWindowProps = $props();
+    interface TranslatedWordProps {
+        translatedWord: TranslatedText;
+        translateEnglishToDovahzul: boolean;
+    }
 
-    const getTranslatedWordToDisplay = (obj: TranslatedText) => {
-        if (translateEnglishToDovahzul) {
-            return obj.dovahzul !== null ? `${obj.dovahzul[0]} ` : `${obj.english} `;
-        }
+	const { translatedWord, translateEnglishToDovahzul }: TranslatedWordProps = $props();
 
-        return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
-    };
+	const getTranslatedWordToDisplay = (obj: TranslatedText) => {
+		if (translateEnglishToDovahzul) {
+			return obj.dovahzul !== null ? `${obj.dovahzul[0]} ` : `${obj.english} `;
+		}
+
+		return obj.english !== null ? `${obj.english} ` : `${obj.dovahzul?.[0]} `;
+	};
 </script>
 
-{#each translatedText as obj, index (index)}
-    <div class={obj.translated ? 'translated-word' : 'untranslated-word'}>
-        {getTranslatedWordToDisplay(obj)}
-    </div>
-{/each}
 
+	<div class={translatedWord.translated ? 'translated-word' : 'untranslated-word'}>
+		{getTranslatedWordToDisplay(translatedWord)}
+	</div>
 
 <style>
-    .translated-word {
-        border-bottom: green 4px solid;
-        text-align: center;
-        font-size: 2rem;
-        margin: auto 0.3vw auto 0.3vw;
-    }
+	.translated-word {
+		border-bottom: green 4px solid;
+		text-align: center;
+		font-size: 2rem;
+		margin: auto 0.3vw auto 0.3vw;
+	}
 
-    .untranslated-word {
-        text-align: center;
-        font-size: 2rem;
-        margin: auto 0.5vw auto 0.5vw;
-    }
+	.untranslated-word {
+		text-align: center;
+		font-size: 2rem;
+		margin: auto 0.5vw auto 0.5vw;
+	}
 </style>

--- a/src/lib/translated-text-window-props.types.ts
+++ b/src/lib/translated-text-window-props.types.ts
@@ -1,6 +1,0 @@
-import type {TranslatedText} from "./utils/translate-text";
-
-export interface TranslatedTextWindowProps {
-    translatedText: TranslatedText[];
-    translateEnglishToDovahzul: boolean;
-}

--- a/src/lib/translated-text-window-props.types.ts
+++ b/src/lib/translated-text-window-props.types.ts
@@ -1,0 +1,6 @@
+import type {TranslatedText} from "./utils/translate-text";
+
+export interface TranslatedTextWindowProps {
+    translatedText: TranslatedText[];
+    translateEnglishToDovahzul: boolean;
+}


### PR DESCRIPTION
When translating english to dovahzul users can hover over translated words to display translation details.

Translate text now has a green bottom border instead of a block green background.